### PR TITLE
fix: useImageUpload 버튼의 텍스트가 정중앙에 오도록 수정

### DIFF
--- a/client/src/component/user_image_upload/userImageUpload.module.css
+++ b/client/src/component/user_image_upload/userImageUpload.module.css
@@ -20,14 +20,14 @@
   background-color: registerBackground;
   color: white;
   border-radius: 4px;
-  display: inline-block;
   cursor: pointer;
-  text-align: center;
-  padding-top: 4px;
   width: 7.5rem;
   height: 2rem;
   font-weight: 500;
   margin: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .buttonImageDelete {


### PR DESCRIPTION
- userImageUpload 버튼의 이미지 선택 텍스트가 위로 치우쳐져있어서 중앙에 오도록 수정하였습니다.
- buttonImageDelete 버튼은 중앙에 오는듯한데 버튼의 UI가 변경된다면 이또한 같은 작업이 필요할 듯 합니다