### PR TITLE
Fix modal layout shift

### DIFF
--- a/client/src/component/loading/loadingSpinner.module.css
+++ b/client/src/component/loading/loadingSpinner.module.css
@@ -5,7 +5,6 @@
   display: flex;
   top: 50%;
   margin: 0 auto;
-  transform: translateY(-50%);
 }
 
 .spinnerImg {

--- a/client/src/component/modal/login_modal/loginModal.module.css
+++ b/client/src/component/modal/login_modal/loginModal.module.css
@@ -2,12 +2,8 @@
   width: 800px;
   height: 550px;
   box-shadow: rgb(0 0 0 / 9%) 0px 2px 12px 0px;
-  position: relative;
   display: flex;
   flex-direction: column;
-  top: -200%;
-  margin: 0 auto;
-  transform: translateY(-50%);
   animation: loginAnimation 0.5s ease 0s 1 normal forwards running;
 }
 
@@ -77,12 +73,12 @@
 @keyframes loginAnimation {
   0% {
     opacity: 0;
-    top: -100%;
+    transform: translateY(-100%);
   }
 
   100% {
     opacity: 1;
-    top: 50%;
+    transform: translateY(0);
   }
 }
 

--- a/client/src/component/modal/modal_component/modal.jsx
+++ b/client/src/component/modal/modal_component/modal.jsx
@@ -11,36 +11,26 @@ const Modal = ({ name, onClose, visible, children }) => {
 
   return (
     <Portal elementId='modal-root'>
-      <ModalOverlay name={name} visible={visible} />
-      <ModalWrapper onClick={onMaskClick} tabIndex={-1} visible={visible}>
-        {children}
-      </ModalWrapper>
+      <ModalOverlay name={name} visible={visible} onClick={onMaskClick}>
+        <ModalWrapper tabIndex={-1} visible={visible}>
+          {children}
+        </ModalWrapper>
+      </ModalOverlay>
     </Portal>
   );
 };
 
 const ModalWrapper = styled.div`
-  box-sizing: border-box;
-  display: ${(props) => (props.visible ? 'block' : 'none')};
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1000;
-  overflow: auto;
-  outline: 0;
-  top:0;
-}
+  display: flex;
+  align-items: center;
 `;
 
 const ModalOverlay = styled.div`
-  box-sizing: border-box;
-  display: ${(props) => (props.visible ? 'block' : 'none')};
+  display: ${(props) => (props.visible ? 'flex' : 'none')};
+  justify-content: center;
+  align-items: center;
   position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
   background: ${(props) => (props.name === 'loading' ? 'white' : 'rgba(77, 77, 77, 0.5)')};
   z-index: 999;
 `;

--- a/client/src/component/user_image_upload/userImageUpload.module.css
+++ b/client/src/component/user_image_upload/userImageUpload.module.css
@@ -20,14 +20,14 @@
   background-color: registerBackground;
   color: white;
   border-radius: 4px;
-  display: inline-block;
   cursor: pointer;
-  text-align: center;
-  padding-top: 4px;
   width: 7.5rem;
   height: 2rem;
   font-weight: 500;
   margin: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .buttonImageDelete {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,7 @@
 @import url(./common/fonts.css);
-
+html {
+  overflow-x: hidden;
+}
 body {
   margin: 0;
   font-family: 'Spoqa Han Sans Neo', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',


### PR DESCRIPTION
해결하려는 이슈의 간략한 내용
- 1. 모달 등장시 다른 요소들이 살짝 밀려나는 layout shift 문제
- 2. 모달부분 css 코드 간략화

수정/개선 방향
- 1. html 태그에 overflox-x를 hidden으로 줘서 모달과 스크롤바가 공존하게 했습니다.
- 2. ModalOverlay와 ModalWrapper를 부모자식 관계로 바꿔 UI는 같으나 css코드의 양을 줄였습니다. 
- 3. ModalWrapper의 children으로 오는 모달들의 등장애니메이션을 top방식에서 translate방식으로 수정했습니다. - 브라우저 렌더링 과정의 reflow를 줄이는 효과가 있습니다.

확인해주셔야 할 점
- 1. 스크롤바가 생기는 UI적 문제 vs layout shift로 인한 UI적 문제를 타협하시거나 다른 방법을 모색해야 할 듯 합니다.
- 2. 제가 데이터가 없어서 데이터를 필요로하는 페이지의 모달들은 확인해보지 못했습니다. 모달의 UI가 어그러진다면 translateY쪽 코드를 수정하시면 문제가 해결될 것이라고 생각합니다.  ex) CancelButton, StudyItem